### PR TITLE
Add missing command structure functionality

### DIFF
--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -4,17 +4,25 @@
   Read https://discord.com/developers/docs/interactions/slash-commands first to understand the structure of slash commands."
   (:require [slash.util :refer [omission-map]]))
 
+(def command-types
+  "Map of command type names (keywords) to numerical command type identifiers."
+  {:chat-input 1
+   :user 2
+   :message 3})
+
 (defn command
   "Create a top level command.
 
-  See https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-structure"
-  [name description & {:keys [default-permission guild-id options]}]
+  See https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-structure.
+  `type` is one of the keys in [[command-types]]."
+  [name description & {:keys [default-permission guild-id options type]}]
   (omission-map
    :name name
    :description description
    :options options
    :guild_id guild-id
-   :default_permission default-permission))
+   :default_permission default-permission
+   :type (some-> type command-types)))
 
 (defn sub-command-group
   "Create a sub command group option."

--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -14,7 +14,7 @@
   "Create a top level command.
 
   See https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-structure.
-  `type` is one of the keys in [[command-types]]."
+  `:type` must be one of the keys in [[command-types]], if given."
   [name description & {:keys [default-permission guild-id options type]}]
   (omission-map
    :name name

--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -24,6 +24,20 @@
    :default_permission default-permission
    :type (some-> type command-types)))
 
+(defn message-command
+  "Create a top level message command.
+
+  See https://discord.com/developers/docs/interactions/application-commands#message-commands."
+  [name & {:keys [default-permission]}]
+  (command name "" :default-permission default-permission :type :message))
+
+(defn user-command
+  "Create a top level user command.
+
+  See https://discord.com/developers/docs/interactions/application-commands#user-commands."
+  [name & {:keys [default-permission]}]
+  (command name "" :default-permission default-permission :type :user))
+
 (defn sub-command-group
   "Create a sub command group option."
   [name description & sub-commands]

--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -53,15 +53,33 @@
    :mentionable 9
    :number 10})
 
+(def channel-types
+  "Map of channel type names (keywords) to numerical channel type identifiers."
+  {:guild-text 0
+   :dm 1
+   :guild-voice 2
+   :group-dm 3
+   :guild-category 4
+   :guild-news 5
+   :guild-store 6
+   :guild-news-thread 10
+   :guild-public-thread 11
+   :guild-private-thread 12
+   :guild-stage-voice 13})
+
 (defn option
-  "Create a regular option."
-  [name description type & {:keys [required choices]}]
+  "Create a regular option.
+
+  `:channel-types` must be a collection of keys from [[channel-types]], if given.
+  This may only be set when `type` is `:channel`."
+  [name description type & {:keys [required choices] ch-types :channel-types}]
   (omission-map
    :type (option-types type type)
    :name name
    :description description
    :required required
-   :choices choices))
+   :choices choices
+   :channel_types (some->> ch-types (map channel-types))))
 
 (defn choice
   "Create an option choice for a choice set."


### PR DESCRIPTION
This PR adds:

- ability to set command type
- functions to create message and user commands directly
- `:channel-type` optional argument for option creation