### PR TITLE
API Additions

### DIFF
--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -47,14 +47,16 @@
 
 (defn option
   "Create a regular option."
-  [name description type & {:keys [required choices autocomplete]}]
+  [name description type & {:keys [required choices autocomplete min-value max-value]}]
   (omission-map
    :type (option-types type type)
    :name name
    :description description
    :required required
    :choices choices
-   :autocomplete autocomplete))
+   :autocomplete autocomplete
+   :min_value min-value
+   :max_value max-value))
 
 (defn choice
   "Create an option choice for a choice set."

--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -47,13 +47,14 @@
 
 (defn option
   "Create a regular option."
-  [name description type & {:keys [required choices]}]
+  [name description type & {:keys [required choices autocomplete]}]
   (omission-map
    :type (option-types type type)
    :name name
    :description description
    :required required
-   :choices choices))
+   :choices choices
+   :autocomplete autocomplete))
 
 (defn choice
   "Create an option choice for a choice set."

--- a/src/slash/core.clj
+++ b/src/slash/core.clj
@@ -7,7 +7,8 @@
   See https://discord.com/developers/docs/interactions/slash-commands#interaction-object-interaction-request-type"
   {1 :ping
    2 :application-command
-   3 :message-component})
+   3 :message-component
+   4 :application-command-autocomplete})
 
 (defn route-interaction
   "Takes a handler map and an interaction and routes the interaction to the correct handler.

--- a/src/slash/gateway.clj
+++ b/src/slash/gateway.clj
@@ -11,7 +11,8 @@
   The interaction handlers in this map simply don't do anything."
   {:ping nop
    :application-command nop
-   :message-component nop})
+   :message-component nop
+   :application-command-autocomplete nop})
 
 (defn wrap-response-return
   "Middleware that takes the return value of an interaction handler and consumes it in some way.

--- a/src/slash/response.clj
+++ b/src/slash/response.clj
@@ -27,6 +27,12 @@
   {:type 7
    :data data})
 
+(defn autocomplete-result
+  "Return suggestions for autocompletion (only for autocomplete interactions)."
+  [choices]
+  {:type 8
+   :data {:choices choices}})
+
 (defn ephemeral
   "Takes an interaction response and makes it ephemeral."
   [response]

--- a/src/slash/webhook.clj
+++ b/src/slash/webhook.clj
@@ -15,4 +15,5 @@
   Returns a 400 Bad Request response for all interactions except PING, for which it returns a PONG response."
   {:ping (constantly pong)
    :application-command interaction-not-supported
-   :message-component interaction-not-supported})
+   :message-component interaction-not-supported
+   :application-command-autocomplete interaction-not-supported})

--- a/test/slash/command/structure_test.clj
+++ b/test/slash/command/structure_test.clj
@@ -27,13 +27,20 @@
   (is (= {:type 3
           :name "baz"
           :description "quz"
-          :required true}
-         (option "baz" "quz" :string :required true)))
+          :required true
+          :autocomplete true}
+         (option "baz" "quz" :string :required true :autocomplete true)))
   (is (= {:type 6
           :name "baz"
           :description "quz"
           :choices [:foo :bar]}
-         (option "baz" "quz" :user :choices [:foo :bar]))))
+         (option "baz" "quz" :user :choices [:foo :bar])))
+  (is (= {:type 4
+          :name "baz"
+          :description "quz"
+          :min_value -56
+          :max_value 42}
+         (option "baz" "quz" :integer :min-value -56 :max-value 42))))
 
 (deftest choice-test
   (is (= {:name "foo"

--- a/test/slash/core_test.clj
+++ b/test/slash/core_test.clj
@@ -5,12 +5,14 @@
 (def handlers
   {:ping (constantly :ping)
    :application-command (constantly :cmd)
-   :message-component (constantly :cmp)})
+   :message-component (constantly :cmp)
+   :application-command-autocomplete (constantly :ac)})
 
 (deftest routing-test
   (testing "Interaction handler routing"
     (is (= :ping (route-interaction handlers {:type 1})))
     (is (= :cmd (route-interaction handlers {:type 2})))
-    (is (= :cmp (route-interaction handlers {:type 3}))))
+    (is (= :cmp (route-interaction handlers {:type 3})))
+    (is (= :ac (route-interaction handlers {:type 4}))))
   (testing "Interaction handler arguments"
     (is (= {:type 2 :data :foo} (route-interaction (constantly identity) {:type 2 :data :foo})))))


### PR DESCRIPTION
This PR adds support for two features Discord has added to the interaction/slash command API:

- Support for slash command autocompletion (new interaction type and response, new option field)
- Support for `min_value` and `max_value` on options