### PR TITLE
Add clj-kondo hooks and config example

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,4 @@
+{:hooks {:analyze-call {slash.command/handler hooks.slash/handler
+                        slash.command/defhandler hooks.slash/defhandler
+                        slash.command/group hooks.slash/group
+                        slash.command/defpaths hooks.slash/defpaths}}}

--- a/.clj-kondo/hooks/slash.clj
+++ b/.clj-kondo/hooks/slash.clj
@@ -1,0 +1,38 @@
+(ns hooks.slash
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn strip-pattern [pattern]
+  (api/vector-node (vec (remove api/string-node? (:children pattern)))))
+
+(defn transform-handler-contents [[pattern interact-sym opt-sym & body]]
+  (api/list-node
+   (list*
+    (api/token-node 'let)
+    (api/vector-node
+     [(strip-pattern pattern) (api/token-node nil)
+      interact-sym (api/token-node nil)
+      opt-sym (api/token-node nil)])
+    body)))
+
+(defn handler [{:keys [node]}]
+  {:node (transform-handler-contents (rest (:children node)))})
+
+(defn defhandler [{:keys [node]}]
+  (let [[name & handler-contents] (rest (:children node))]
+    {:node (api/list-node (list (api/token-node 'def) name (transform-handler-contents handler-contents)))}))
+
+(defn group [{:keys [node]}]
+  (let [[pattern & handlers] (rest (:children node))]
+    {:node (api/list-node
+            (list*
+             (api/token-node 'let)
+             (api/vector-node [(strip-pattern pattern) (api/token-node nil)])
+             handlers))}))
+
+(defn defpaths [{:keys [node]}]
+  (let [[name & handlers] (rest (:children node))]
+    {:node (api/list-node
+            (list
+             (api/token-node 'def)
+             name
+             (api/vector-node (vec handlers))))}))

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /.prepl-port
+.clj-kondo/.cache/
 .hgignore
 .hg/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ slash is environment-agnostic, extensible through middleware and works directly 
 
 **slash is currently in a Proof-of-Concept-phase and more features are to be added.**\
 Such features include:
- - Add functions to create components, similar to slash command helpers
  - Add more middleware: argument validation, permission checks, ...
 
 ## Command Structure Definition

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ responses from your handlers and let the middleware respond via REST. You only n
   (events/message-pump! event-channel (partial events/dispatch-handlers {:interaction-create event-handler})))
 ```
 
+## clj-kondo support for macros
+
+You can find a clj-kondo config that gets rid of "unresolved symbol" warnings in [.clj-kondo/](./.clj-kondo). Just copy [the hooks](./.clj-kondo/hooks) to your clj-kondo config folder (preserving the directory structure, of course!) and add this to your `config.edn`:
+
+``` clojure
+{:hooks {:analyze-call {slash.command/handler hooks.slash/handler
+                        slash.command/defhandler hooks.slash/defhandler
+                        slash.command/group hooks.slash/group
+                        slash.command/defpaths hooks.slash/defpaths}}}
+```
 
 ## License
 


### PR DESCRIPTION
This PR adds clj-kondo hooks for the macros defined in `slash.command` as well as a readme note on how to include them. These hooks configure clj-kondo to lint uses of these macros correctly.