### PR TITLE
Use linked maps for option maps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,6 @@
   :url "https://github.com/JohnnyJayJay/slash"
   :license {:name "MIT License"
             :url "https://mit-license.org"}
-  :dependencies [[org.clojure/clojure "1.10.3"]]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [frankiesardo/linked "1.3.0"]]
   :repl-options {:init-ns slash.core})

--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -1,5 +1,6 @@
 (ns slash.command
-  "The command namespace contains functions to create command handlers and dispatch commands.")
+  "The command namespace contains functions to create command handlers and dispatch commands."
+  (:require [linked.core :as linked]))
 
 (defn path
   "Given a command, returns the fully qualified command name as a vector.
@@ -27,7 +28,7 @@
   [command]
   (loop [layer command]
     (if (actual-command? layer)
-      (zipmap (map (comp keyword :name) (:options layer)) (map :value (:options layer)))
+      (into (linked/map) (map (juxt (comp keyword :name) :value) (:options layer)))
       (recur (-> layer :options first)))))
 
 (defn wrap-options


### PR DESCRIPTION
Up until now, `option-map` would not preserve the order of options because a regular hash map was used. This uses a linked hash map now, thus the order is preserved.