### PR TITLE
Add facilities for autocompletion in handlers

### DIFF
--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -33,13 +33,24 @@
    (linked/map)
    (map (juxt (comp keyword :name) :value) (:options (find-actual-command command)))))
 
+(defn raw-options
+  "Returns the options of a command as-is, i.e. as a list of maps.
+
+  The command is the data associated with an interaction create event of type 2 as Clojure data.
+  'options' here means the options the user sets, like `baz` in `/foo bar baz: 3`, but not `bar`."
+  [command]
+  (:options (find-actual-command command)))
+
 (defn wrap-options
   "Middleware that attaches the `:option-map` (obtained by [[option-map]]) to the command, if not already present."
   [handler]
   (fn [{command :data :as interaction}]
     (handler (cond-> interaction
                (not (contains? command :option-map))
-               (assoc-in [:data :option-map] (option-map command))))))
+               (assoc-in [:data :option-map] (option-map command))
+
+               (not (contains? command :raw-options))
+               (assoc-in [:data :raw-options] (raw-options command))))))
 
 (defn wrap-path
   "Middleware that attaches the `:path` (obtained by [[path]]) to the command, if not already present."

--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -51,7 +51,7 @@
                (not (contains? command :option-map))
                (assoc-in [:data :option-map] (option-map command))
 
-               (not (contains? command :raw-options))
+               (not (contains? command :full-option-map))
                (assoc-in [:data :full-option-map] (full-option-map command))))))
 
 (defn wrap-path

--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -20,16 +20,18 @@
 (defn- actual-command? [layer]
   (-> layer :options first :type #{1 2} not))
 
+(defn- find-actual-command [command]
+  (->> command (iterate (comp first :options)) (filter actual-command?) first))
+
 (defn option-map
   "Returns the options of a command as a map of keywords -> values.
 
   The command is the data associated with an interaction create event of type 2 as Clojure data.
   'options' here means the options the user sets, like `baz` in `/foo bar baz: 3`, but not `bar`."
   [command]
-  (loop [layer command]
-    (if (actual-command? layer)
-      (into (linked/map) (map (juxt (comp keyword :name) :value) (:options layer)))
-      (recur (-> layer :options first)))))
+  (into
+   (linked/map)
+   (map (juxt (comp keyword :name) :value) (:options (find-actual-command command)))))
 
 (defn wrap-options
   "Middleware that attaches the `:option-map` (obtained by [[option-map]]) to the command, if not already present."

--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -126,14 +126,16 @@
   The function returned by this already has the [[wrap-options]], [[wrap-check-path]] and [[wrap-path]] middlewares applied."
   {:style/indent 3}
   [pattern interaction-binding options & body]
-  `(-> (fn [{{option-map# :option-map path# :path} :data :as interaction#}]
-         (let-placeholders ~pattern path#
-           (let [~interaction-binding interaction#
-                 ~(if (vector? options) `{:keys [~@options]} options) option-map#]
-             ~@body)))
-       wrap-options
-       (wrap-check-path ~(replace-symbols pattern))
-       wrap-path))
+  (let [full? (:full (meta options))]
+    `(-> (fn [{{option-map# ~(if full? :full-option-map :option-map) path# :path} :data
+               :as interaction#}]
+           (let-placeholders ~pattern path#
+                             (let [~interaction-binding interaction#
+                                   ~(if (vector? options) `{:keys [~@options]} options) option-map#]
+                               ~@body)))
+         wrap-options
+         (wrap-check-path ~(replace-symbols pattern))
+         wrap-path)))
 
 (defmacro defhandler
   "Utility macro for `(def my-handler (handler ...))` (see [[handler]])"

--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -46,7 +46,7 @@
 (defn focused-option
   "Given a list of command options, returns the name of the option that is currently in focus (or `nil` if none is in focus)."
   [options]
-  (->> options (filter :focused) first :name))
+  (->> options (filter :focused) first :name keyword))
 
 (defn wrap-options
   "Middleware that attaches the following keys to the interaction data (if not already applied):

--- a/src/slash/command.clj
+++ b/src/slash/command.clj
@@ -33,13 +33,15 @@
    (linked/map)
    (map (juxt (comp keyword :name) :value) (:options (find-actual-command command)))))
 
-(defn raw-options
-  "Returns the options of a command as-is, i.e. as a list of maps.
+(defn full-option-map
+  "Returns the options of a command as a map of keywords -> option objects.
 
   The command is the data associated with an interaction create event of type 2 as Clojure data.
   'options' here means the options the user sets, like `baz` in `/foo bar baz: 3`, but not `bar`."
   [command]
-  (:options (find-actual-command command)))
+  (into
+   (linked/map)
+   (map (juxt (comp keyword :name) identity) (:options (find-actual-command command)))))
 
 (defn wrap-options
   "Middleware that attaches the `:option-map` (obtained by [[option-map]]) to the command, if not already present."
@@ -50,7 +52,7 @@
                (assoc-in [:data :option-map] (option-map command))
 
                (not (contains? command :raw-options))
-               (assoc-in [:data :raw-options] (raw-options command))))))
+               (assoc-in [:data :full-option-map] (full-option-map command))))))
 
 (defn wrap-path
   "Middleware that attaches the `:path` (obtained by [[path]]) to the command, if not already present."

--- a/src/slash/command/structure.clj
+++ b/src/slash/command/structure.clj
@@ -96,7 +96,7 @@
    :autocomplete autocomplete
    :min_value min-value
    :max_value max-value
-   :channel_types (some->> ch-types (map channel-types))))
+   :channel_types (some->> ch-types (mapv channel-types))))
 
 (defn choice
   "Create an option choice for a choice set."

--- a/test/slash/command/structure_test.clj
+++ b/test/slash/command/structure_test.clj
@@ -40,7 +40,12 @@
           :description "quz"
           :min_value -56
           :max_value 42}
-         (option "baz" "quz" :integer :min-value -56 :max-value 42))))
+         (option "baz" "quz" :integer :min-value -56 :max-value 42)))
+  (is (= {:type 7
+          :name "baz"
+          :description "quz"
+          :channel_types [0 2]}
+         (option "baz" "quz" :channel :channel-types [:guild-text :guild-voice]))))
 
 (deftest choice-test
   (is (= {:name "foo"


### PR DESCRIPTION
This PR adds new facilities to the `handler` macro and more generally to the `wrap-options` middleware:
- the command now has a `:full-option-map` map attached whose value are the entire option objects, not just their values
- it also has `:focused-option`, which is the name of the option currently in focus (if any)
- to bind to the "full" option map instead of the regular one like before, you can use metadata in the handler macro:
 ```clj
(defhandler foo ["bar"] _ ^:full [opt1 opt2] nil)
```

**TODO**:
- [x] Tests